### PR TITLE
docs(Contributing): add commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,72 @@ _TODO add more info about good tests_
 
 ### Commit Message Guidelines
 
-_TODO add_
+Tine 2.0 uses [Conventional Commits](https://conventionalcommits.org/) style commit messages:
+ 
+    <type>[(optional scope)]: MESSAGE
+    
+    [optional body]
+    
+    [optional footer]
+
+Example:
+
+    feature(Addressbook): adds type-ahead to some contact fields
+    
+    * company
+    * unit
+    * address data
+    
+    closes #289
+
+Another:
+    
+    fix(Phone): improve handling of empty phone numbers
+
+    ... when looking for the matching contact
+
+See also the [AngularJS commit guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
+
+<type> can be one of the following:
+
+- tweak
+- hack
+- fix
+- feature
+- build
+- docs
+- perf
+- refactor
+- style
+- test
+- config
+- script
+
+Some example scopes:
+
+- APPNAME like Addressbook, Calendar, Tasks
+- Tests / Unittests
+- Cli
+- Import, Export
+- Setup
+
+You should reference a GitHub issue (if exists) like this:
+
+    See #1234
+    
+If the commit closes an issue, it should be done like this:
+
+    Closes #1234
+    
+(or any other "closing" keyword - see https://help.github.com/articles/closing-issues-using-keywords/ for reference)
+
+If the commit reverts a previous commit, it should begin with revert:, followed by the header of the reverted commit.
+In the body it should say: "This reverts commit <hash>", where the hash is the SHA of the commit being reverted.
+
+We also use some annotations to mark commits for documentation follow-ups:
+
+- @usermanual (User manual needs to be updated because of this commit)
+- @releasenotes (RELEASENOTES need to be updated because of this commit)
 
 ## Reporting Bugs
 
@@ -59,7 +124,7 @@ _TODO add more_
 
 ### Coding Standards
 
-_TODO add more_
+For PHP Code, we use the [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md) and [PSR-2](https://www.php-fig.org/psr/psr-2/) Coding Standards.
 
 ## Asking and Answering Questions
 
@@ -68,3 +133,4 @@ _TODO add more_
 ## Additional Resources
 
 * [Guidelines for CONTRIBUTING](https://help.github.com/articles/setting-guidelines-for-repository-contributors/)
+* [AngularJS Commit Message Guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)


### PR DESCRIPTION
* add commit message guidelines (inspired by conventionalcommits.org)
* also add PHP Coding Standards
