### PR TITLE
Automatically attach mail signature to mails send via ActiveSync

### DIFF
--- a/tine20/Felamimail/Frontend/ActiveSync.php
+++ b/tine20/Felamimail/Frontend/ActiveSync.php
@@ -380,7 +380,7 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
             if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(
                 __METHOD__ . '::' . __LINE__ . " Send Message with subject " . $subject . " (saveInSent: " . $saveInSent . ")");
             
-            $mail = Tinebase_Mail::createFromZMM($incomingMessage);
+            $mail = Tinebase_Mail::createFromZMM($incomingMessage, null, $account->signature);
         
             Felamimail_Controller_Message_Send::getInstance()->sendZendMail($account, $mail, (bool)$saveInSent);
         }


### PR DESCRIPTION
This PR implements server side attachment of account mail signatures to text/html and text/plain mail parts.
This works fine in our production environment, but I am not sure if I missed something. 
Would be nice if one of the core developers could have a look.