### PR TITLE
fix(docs): security has to be reported via mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Each [Tine 2.0 Business Edition](http://www.tine20.com) is maintained with secur
 years. Our [partners](https://www.tine20.com/partner/) offer a wide range of commercial support for different business needs.
 
 ## Reporting security issues
-If you found any security relevant issue you can mail us [security@tine20.com](mailto:security@tine20.com). You can also create issues in our [forge](https://forge.tine20.org) and explain the issue there. Make sure you tick the privat flag there and write us your ticket number to the mail above! Once we resolved the issue, we can disable the privat state and announce it to the public.
+If you found any security relevant issue you can mail us [security@tine20.com](mailto:security@tine20.com).
 
 ## Server Requirements
 * Webserver like [Apache](https://httpd.apache.org/), [Ngnix](https://www.nginx.com/), …


### PR DESCRIPTION
Since forge.tine20.org redirects to the github issues it is no longer possible to report security issues via forge.