### PR TITLE
Fix uncaught TypeError

### DIFF
--- a/tine20/Tinebase/js/widgets/relation/GridRenderer.js
+++ b/tine20/Tinebase/js/widgets/relation/GridRenderer.js
@@ -48,7 +48,7 @@ Ext.extend(Tine.widgets.relation.GridRenderer, Ext.Component, {
         }
         
         if (! this.recordClass) {
-            if (! Tine[this.foreignApp]) {
+            if (! Tine[this.foreignApp] || ! Tine[this.foreignApp].Model) {
                 Tine.log.warn('Tine.widgets.relation.GridRenderer::render - ForeignApp not found: ' + this.foreignApp);
                 return '';
             }


### PR DESCRIPTION
Fix for "Cannot read property 'Contract' of undefined at Tine.widgets.relation.GridRenderer.render" error.

The [fix](https://github.com/tine20/tine20/commit/d86303887b5f63c330beaf9e17cb9c20c8a4f18a) in 2018.08.2 seems not to work for us as for some reason `.Model` was undefined in case of Sales.Contacts. This fix seems to work for us fine.