### PR TITLE
Fix set content_type in parseStructure

### DIFF
--- a/tine20/Felamimail/Model/Message.php
+++ b/tine20/Felamimail/Model/Message.php
@@ -472,7 +472,7 @@ class Felamimail_Model_Message extends Tinebase_Record_Abstract
         if (Tinebase_Core::isLogLevel(Zend_Log::TRACE)) Tinebase_Core::getLogger()->trace(__METHOD__ . '::' . __LINE__
             . ' Parsing structure: ' . print_r($this->structure, TRUE));
         
-        $this->content_type  = isset($this->structure['contentType']) ? $this->structure['contentType'] : Zend_Mime::TYPE_TEXT;
+        $this->content_type = (array_key_exists('contentType', $this->structure) && (!is_null($this->structure['contentType']))) ? $this->structure['contentType'] : Zend_Mime::TYPE_TEXT;
         $this->_setBodyContentType();
     }
     


### PR DESCRIPTION
This is a really strange issue.
Tine20 will recognize the content_type of some text/html emails (no multipart, just text/html body) as text/plain, which leads to display errors.
I could find the core of the issue, but can't really understand what is happening.
A log output of `$this->structure['contentType']` results in `text/html` but `isset($this->structure['contentType'])` returns false.
`array_key_exists('contentType', $this->structure)` returns true.
`is_null($this->structure['contentType'])` returns false.
My patch fixes the issue, but as I am not a php expert, I do not know what is the actual problem here.

Tine 2.0 is running on Ubuntu 18.04 with PHP 7.2.19.