### PR TITLE
Ensure password encoding for login is always UTF-8

### DIFF
--- a/tine20/Tinebase/Auth.php
+++ b/tine20/Tinebase/Auth.php
@@ -230,7 +230,12 @@ class Tinebase_Auth
                 array($zaae->getMessage())
             );
         }
-        
+        if (!mb_detect_encoding($_password, "UTF-8", true)) {
+            $passwordEncoding = mb_detect_encoding($_password, "ISO-8859-1,ISO-8859-15", true);
+            if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(
+                __METHOD__ . '::' . __LINE__ .' Non UTF-8 password corrected, found ' . $passwordEncoding);
+            $_password = mb_convert_encoding($_password, "UTF-8", $passwordEncoding);
+        }
         $this->_backend->setCredential($_password);
 
         try {


### PR DESCRIPTION
See issue #7038, this should REPLACE patch f1c2b35.
(tested JSON-login by Firefox; ActiveSync iOS 13.1.1; Android, older version)