### PR TITLE
fix: use succeed instead of succseed

### DIFF
--- a/tests/tine20/Tinebase/Frontend/JsonTest.php
+++ b/tests/tine20/Tinebase/Frontend/JsonTest.php
@@ -173,13 +173,13 @@ class Tinebase_Frontend_JsonTest extends TestCase
     {
         // de_LU -> de
         $this->_instance->setLocale('de_LU', FALSE, FALSE);
-        $this->assertEquals('de', (string)Zend_Registry::get('locale'), 'Fallback to generic german did not succseed');
+        $this->assertEquals('de', (string)Zend_Registry::get('locale'), 'Fallback to generic german did not succeed');
         
         $this->_instance->setLocale('zh', FALSE, FALSE);
-        $this->assertEquals('zh_CN', (string)Zend_Registry::get('locale'), 'Fallback to simplified chinese did not succseed');
+        $this->assertEquals('zh_CN', (string)Zend_Registry::get('locale'), 'Fallback to simplified chinese did not succeed');
         
         $this->_instance->setLocale('foo_bar', FALSE, FALSE);
-        $this->assertEquals('en', (string)Zend_Registry::get('locale'), 'Exception fallback to english did not succseed');
+        $this->assertEquals('en', (string)Zend_Registry::get('locale'), 'Exception fallback to english did not succeed');
     }
     
     /**

--- a/tine20/Tinebase/Frontend/Json.php
+++ b/tine20/Tinebase/Frontend/Json.php
@@ -524,7 +524,7 @@ class Tinebase_Frontend_Json extends Tinebase_Frontend_Json_Abstract
         if ($authResult->isValid()) {
             $response = array(
                 'status'    => 'success',
-                'msg'       => 'authentication succseed',
+                'msg'       => 'authentication succeed',
                 //'loginUrl'  => 'someurl',
             );
         } else {

--- a/tine20/Tinebase/js/util/waitFor.es6.js
+++ b/tine20/Tinebase/js/util/waitFor.es6.js
@@ -15,7 +15,7 @@ export default function (condition, timeout, interval) {
       let result = condition()
       if (!result) {
         if (new Date().getTime() > until) {
-          return reject(new Error('did not succseed in given time interval'))
+          return reject(new Error('did not succeed in given time interval'))
         } else {
           return window.setTimeout(fn, interval)
         }


### PR DESCRIPTION
This PR fixes a small typo in the word `succeed`.