### PR TITLE
Fix: Handle aliases if smtpAliasesDispatchFlag not set

### DIFF
--- a/tine20/Felamimail/js/MessageEditDialog.js
+++ b/tine20/Felamimail/js/MessageEditDialog.js
@@ -1299,7 +1299,7 @@ Tine.Felamimail.MessageEditDialog = Ext.extend(Tine.widgets.dialog.EditDialog, {
                 // add identities / aliases to store (for systemaccounts)
                 var user = Tine.Tinebase.registry.get('currentAccount');
                 var systemAliases = _.get(user, 'emailUser.emailAliases', []);
-                if (Tine.Tinebase.registry.get('smtpAliasesDispatchFlag')) {
+                if ((systemAliases.length > 0) && (typeof systemAliases[0].dispatch_address !== 'undefined')) {
                     var systemAliasAdresses = _.reduce(systemAliases, (aliases, alias) => {
                         if (!!+alias.dispatch_address) {
                             aliases.push(alias.email);


### PR DESCRIPTION
Fix for issue #7304. Although the flag is not set (Tine.Tinebase.registry.get('smtpAliasesDispatchFlag') == false), alias is an object {email:...,dispatch_address}. To handle it properly it is preferable to test for being such object instead of the flag.