### PR TITLE
Fix: Addendum to commit 37b61a4, fix for non-system accounts

### DIFF
--- a/tine20/Felamimail/js/MessageEditDialog.js
+++ b/tine20/Felamimail/js/MessageEditDialog.js
@@ -1298,7 +1298,7 @@ Tine.Felamimail.MessageEditDialog = Ext.extend(Tine.widgets.dialog.EditDialog, {
             if (account.get('type') === 'system') {
                 // add identities / aliases to store (for systemaccounts)
                 var user = Tine.Tinebase.registry.get('currentAccount');
-                var systemAliases = _.get(user, 'emailUser.emailAliases', []);
+                var systemAliases = _.get(user, 'emailUser.emailAliases', []) || [];
                 if ((systemAliases.length > 0) && (typeof systemAliases[0].dispatch_address !== 'undefined')) {
                     var systemAliasAdresses = _.reduce(systemAliases, (aliases, alias) => {
                         if (!!+alias.dispatch_address) {


### PR DESCRIPTION
Fix for #7315, create MessageEdit Dialog when accounts do not support mail aliases at all

My first patch slipped through my dev and production system as I do not use non-system accounts... 