### PR TITLE
fix(Calendar/CalDAV): fix URI of deleted events

### DIFF
--- a/tine20/Calendar/Convert/Event/VCalendar/Abstract.php
+++ b/tine20/Calendar/Convert/Event/VCalendar/Abstract.php
@@ -1006,8 +1006,11 @@ class Calendar_Convert_Event_VCalendar_Abstract extends Tinebase_Convert_VCalend
                     } elseif (preg_match('/mailto:(?P<email>.*)/i', $property->getValue(), $matches)) {
                         $email = $matches['email'];
                     }
+                    if (($email !== null) && is_string($email)) {
+                        $email = trim($email);
+                    }
                     
-                    if ($email !== null) {
+                    if (!empty($email)) {
                         // it's not possible to change the organizer by spec
                         if (empty($event->organizer)) {
                             $name = isset($property['CN']) ? $property['CN']->getValue() : $email;

--- a/tine20/Tinebase/WebDav/Plugin/SyncToken.php
+++ b/tine20/Tinebase/WebDav/Plugin/SyncToken.php
@@ -198,6 +198,10 @@ class Tinebase_WebDav_Plugin_SyncToken extends \Sabre\DAV\ServerPlugin
         foreach ($properties as $href => $entries) {
             if (count($entries) === 0) { //404
                 $response = $dom->createElement('d:response');
+                // Make sure the URI sent is equal to the one sent by a
+                // Sabre\DAV\Property\Response.
+                $href = Sabre\DAV\URLUtil::encodePath($href);
+                $href = $this->server->getBaseUri() . $href;
                 $href = $dom->createElement('d:href', $href);
                 $response->appendChild($href);
                 $status = $dom->createElement('d:status', $this->server->httpResponse->getStatusMessage(404));


### PR DESCRIPTION
This commit fixes the URI of deleted calendar events in REPORT responses.

The URIs for deleted events are handled in [1] directly, while the URIs for
all other events (created, changed, etc.) are handled in [2].

Both code paths should result in the exact same URIs. At least the
Thunderbird Lightning extension relies on the URIs to match.

[1] Tinebase_WebDav_Plugin_SyncToken::generateMultiStatus
[2] Sabre\DAV\Property\Response::serialize