### PR TITLE
fix(ActiveSync/Autodiscover) Implicit Auth by Mail

### DIFF
--- a/tine20/ActiveSync/Server/Http.php
+++ b/tine20/ActiveSync/Server/Http.php
@@ -33,6 +33,10 @@ class ActiveSync_Server_Http extends Tinebase_Server_Abstract implements Tinebas
                 $authData = $this->_getAuthData($this->_request);
                 if (count($authData) === 2) {
                     list($loginName, $password) = $authData;
+                    // Autodiscover comes always by mail not by username, if feature is activated enable auth, too.
+                    if ( true === Tinebase_Config::getInstance()->featureEnabled(Tinebase_Config::FEATURE_AUTODISCOVER) ) {
+                        Tinebase_Config::getInstance()->set(Tinebase_Config::AUTHENTICATION_BY_EMAIL, true);
+                    }
                 } else {
                     Tinebase_Core::getLogger()->debug(__METHOD__ . '::' . __LINE__ . ' auth data: '
                         . print_r($authData, true));


### PR DESCRIPTION
Enabling Autodiscover requires to allow logins by mailAddress not loginName. Android and auto-configured phones will always advertise mailAddress only. The feature AUTODISCOVER is rendered dysfunctional otherwise (and the user/admin does not know, only usernames is standard). Without prejudice for other apps I propose to enforce AUTHENTICATION_BY_EMAIL for ActiveSync.

See also my fix for AUTHENTICATION_BY_EMAIL and LDAP backends. 