### PR TITLE
Fix (Tb ldap user): Sync accountStatus issue again

### DIFF
--- a/tine20/Tinebase/User.php
+++ b/tine20/Tinebase/User.php
@@ -687,12 +687,12 @@ class Tinebase_User implements Tinebase_Controller_Interface
             'accountHomeDirectory' => false, 
             'accountLoginShell' => false, 
             'visibility' => false, 
-            'accountStatus' => function($options) {
+            'accountStatus' => call_user_func(function() use ($options) {
                 if (isset($options['syncAccountStatus'])) {
                     return (bool) $options['syncAccountStatus'];
                 }
-                return null; 
-            }, 
+                return null;
+            }),
         ];
 
         if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(__METHOD__ . '::' . __LINE__


### PR DESCRIPTION
Fixes issue #7426. @Nachtlichtermeer tested the fix with `setup.php --sync_accounts_from_ldap [--syncaccountstatus]`