### PR TITLE
Posible fix to issue #7481

### DIFF
--- a/tine20/Admin/Frontend/Cli.php
+++ b/tine20/Admin/Frontend/Cli.php
@@ -209,7 +209,43 @@ class Admin_Frontend_Cli extends Tinebase_Frontend_Cli_Abstract
 
         echo 'deleted account ' . $args['accountName'] . PHP_EOL;
     }
+    /**
+     * Delete containers with no users
+     *
+     * @return void
+     */
+    public function deleteUserlessContainers(Zend_Console_Getopt $opts)
+    {
+        if ($opts->d) {
+            echo "--DRY RUN--\n";
+        }
+        // Get an instance of Admin_Frontend_Json
+        $jsonFrontend = new Admin_Frontend_Json();
 
+        // Get all containers
+        $containers = $jsonFrontend->searchContainers([], null);
+
+        foreach ($containers['results'] as $container) {
+          // Check if the container has no users
+          $user_search = $jsonFrontend->searchUsers([
+              [
+                'field' => 'container_id',
+                'operator' => 'equals',
+                'value' => $container['id'],
+              ],
+            ], null);
+            if (empty($user_search['totalcount'])) {
+                // Delete the container
+                $container = $jsonFrontend->getContainer($user_search['filter']['value']);
+                if ($opts->d) {
+                         echo "--DRY RUN-- Found " . $container['name'] . PHP_EOL;
+                } else {
+                        $jsonFrontend->deleteContainers([$container['id']]);
+                        echo 'Deleted container ' . $container['name'] . ' with no users.' . PHP_EOL;
+                }
+            }
+        }
+    }
     /**
      * shorten loginnmes to fit ad samaccountname
      *


### PR DESCRIPTION
From issue #7481 , it was discovered that it was impossible to delete containers that had no user associated after you had deleted a lot of users.
@lab-at-nohl notified that it was possible to build an addon to the CLI functions to delete the containers with [function deleteContainers($ids)](https://github.com/tine20/tine20/blob/010c41591ac0d1b218fa8b2e54038d8ff7456160/tine20/Admin/Frontend/Json.php#L1156)